### PR TITLE
Add resilience to ApiClientBase #7

### DIFF
--- a/BibleTalkAI.OpenAI.Assistants.Json/BibleTalkAI.OpenAI.Assistants.Json.csproj
+++ b/BibleTalkAI.OpenAI.Assistants.Json/BibleTalkAI.OpenAI.Assistants.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
 	<Description>JSON serialization types for BibleTalkAI.OpenAI.Assistants.Models types.</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/BibleTalkAI.OpenAI.Assistants/BibleTalkAI.OpenAI.Assistants.csproj
+++ b/BibleTalkAI.OpenAI.Assistants/BibleTalkAI.OpenAI.Assistants.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
 	<Description>Service collection extensions for adding HTTP client services for the OpenAI Assistants API.</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/BibleTalkAI.OpenAI.AssistantsThreads/BibleTalkAI.OpenAI.AssistantsThreads.csproj
+++ b/BibleTalkAI.OpenAI.AssistantsThreads/BibleTalkAI.OpenAI.AssistantsThreads.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
 	<Description>Service collection extensions for adding HTTP client services for the OpenAI Assistants and Threads APIs.</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/BibleTalkAI.OpenAI.Http.Abstractions/ApiClientBase.cs
+++ b/BibleTalkAI.OpenAI.Http.Abstractions/ApiClientBase.cs
@@ -1,4 +1,7 @@
-﻿using System.Net.Http.Json;
+﻿using Polly;
+using Polly.Retry;
+using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 
 namespace BibleTalkAI.OpenAI.Http.Abstractions;
@@ -6,6 +9,35 @@ namespace BibleTalkAI.OpenAI.Http.Abstractions;
 public abstract class ApiClientBase
     (HttpClient httpClient, JsonSerializerOptions serializerOptions)
 {
+    private static readonly HashSet<HttpStatusCode> _nonRetryableStatusCodes =
+    [
+        HttpStatusCode.Unauthorized,
+        HttpStatusCode.Forbidden,
+        HttpStatusCode.BadRequest
+    ];
+
+    private static readonly ResiliencePipeline _resilience = new ResiliencePipelineBuilder()
+        .AddRetry(new RetryStrategyOptions
+        {
+            ShouldHandle = new PredicateBuilder().Handle<Exception>((exception) => 
+            {
+                if (exception is HttpRequestException httpException && httpException.StatusCode != null)
+                {
+                    // Retry on transient errors (skip non-retryable status codes)
+                    return !_nonRetryableStatusCodes.Contains(httpException.StatusCode.Value);
+                }
+
+                // Retry on all other exceptions
+                return true;
+            }),
+            Delay = TimeSpan.FromMilliseconds(700),
+            MaxRetryAttempts = 3,
+            BackoffType = DelayBackoffType.Exponential,
+            UseJitter = true
+        })
+        .AddTimeout(TimeSpan.FromSeconds(30))
+        .Build();
+
     public ApiClientBase(
         HttpClient httpClient,
         JsonSerializerOptions serializerOptions,
@@ -21,21 +53,31 @@ public abstract class ApiClientBase
 
     protected async ValueTask Delete(Uri endpoint)
     {
-        HttpResponseMessage? _ = await httpClient.DeleteAsync(
-            endpoint);
+        HttpResponseMessage? _ = await _resilience.ExecuteAsync(async cancellationToken 
+            => await httpClient.DeleteAsync(endpoint, cancellationToken));
 
         return;
     }
 
     protected async ValueTask<TResponse?> Get<TResponse>(Uri endpoint)
-        => await httpClient.GetFromJsonAsync<TResponse>(
-            endpoint,
+    {
+        HttpResponseMessage? response = await _resilience.ExecuteAsync(async cancellationToken
+            => await httpClient.GetAsync(endpoint, cancellationToken));
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return default;
+        }
+
+        return await response.Content.ReadFromJsonAsync<TResponse>(
             serializerOptions);
+    }
 
     protected async ValueTask<TResponse?> Post<TResponse>(
         Uri endpoint)
     {
-        HttpResponseMessage? response = await httpClient.PostAsync(endpoint, null);
+        HttpResponseMessage? response = await _resilience.ExecuteAsync(async cancellationToken
+            => await httpClient.PostAsync(endpoint, null, cancellationToken));
 
         if (!response.IsSuccessStatusCode)
         {
@@ -55,9 +97,8 @@ public abstract class ApiClientBase
             typeof(TRequest),
             options: serializerOptions);
 
-        HttpResponseMessage? response = await httpClient.PostAsync(
-            endpoint,
-            requestContent);
+        HttpResponseMessage? response = await _resilience.ExecuteAsync(async cancellationToken
+            => await httpClient.PostAsync(endpoint, requestContent, cancellationToken));
 
         if (!response.IsSuccessStatusCode)
         {

--- a/BibleTalkAI.OpenAI.Http.Abstractions/BibleTalkAI.OpenAI.Http.Abstractions.csproj
+++ b/BibleTalkAI.OpenAI.Http.Abstractions/BibleTalkAI.OpenAI.Http.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
 	<Description>Base types, options, and defaults for the Threads and Assistants API clients.</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.6.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 	

--- a/BibleTalkAI.OpenAI.Threads.Json/BibleTalkAI.OpenAI.Threads.Json.csproj
+++ b/BibleTalkAI.OpenAI.Threads.Json/BibleTalkAI.OpenAI.Threads.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
 	<Description>JSON serialization types for BibleTalkAI.OpenAI.Threads.Models types.</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/BibleTalkAI.OpenAI.Threads/BibleTalkAI.OpenAI.Threads.csproj
+++ b/BibleTalkAI.OpenAI.Threads/BibleTalkAI.OpenAI.Threads.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
 	<Description>Service collection extensions for adding HTTP client services for the OpenAI Threads API.</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Fixes #7 

Use Microsoft.Extensions.Http.Resilience to add Polly retry with exponential backoff and timeout functionality to ApiClientBase